### PR TITLE
#32 fixed 'sleep_duration' variable use inside function handleRateLimit

### DIFF
--- a/lib/tuiter.js
+++ b/lib/tuiter.js
@@ -194,12 +194,12 @@ Tuiter.prototype.resetTimers = function() {
 Tuiter.prototype.handleRateLimit = function(res) {
 	var self = this;
 	self.sleep_duration = (res.header['x-rate-limit-reset']*1000 - new Date()) + 7000;
-  debug('rate limit reached, sleeping during', Math.ceil(sleep_duration/60000), 'minutes');
+  debug('rate limit reached, sleeping during', Math.ceil(self.sleep_duration/60000), 'minutes');
   setTimeout(function() {
   	debug('rate limit reset, resuming extraction...');
 		params = preProcess(res.tuiter.params);
     self.APIRequest(res.tuiter.endpoint, res.tuiter.params, res.tuiter.callback);
-  }, sleep_duration);
+  }, self.sleep_duration);
 };
 
 /*


### PR DESCRIPTION
replaced wrong variable name `sleep_duration` by `self.sleep_duration` in two places, should solve the issue.
